### PR TITLE
feature: add install and list command line args

### DIFF
--- a/bg3_mod_installer.py
+++ b/bg3_mod_installer.py
@@ -294,8 +294,32 @@ def main():
     parser.add_argument(
         "-u", "--userpath",
         help="Root path for Steam userdata (default: '~/.steam/steam/userdata').")
+    parser.add_argument(
+        "-i", "--install",
+        help="install the mod at the supplied path")
+    parser.add_argument(
+        "-l", "--list",
+        action="store_true",
+        help="list installed mods")
+
     args = parser.parse_args()
     installer = BG3ModInstaller(steam_path=args.path, steam_userdata_path=args.userpath)
+
+    if args.install:
+        try:
+            installer.install_mod(Path(args.install))
+        except Exception as e:
+                print(f"Error installing mod: {e}")
+        return
+    
+    if args.list:
+        installed_mods = installer.get_installed_mods()
+        if installed_mods:
+            for i, mod in enumerate(installed_mods):
+                print(f"{i + 1}. {mod['Name']} ({mod['Folder']})")
+        else:
+            print("No mods currently installed.")
+        return
 
     while True:
         choice = display_menu()


### PR DESCRIPTION
Add a list flag, and an install argument so that mods can be installed without invoking the UI.

```
❯ ./bg3_mod_installer.py -h
usage: bg3_mod_installer.py [-h] [-i INSTALL] [-l]

options:
  -h, --help            show this help message and exit
  -i, --install INSTALL
                        install the mod at the provided path
  -l, --list            list the install mods
  ```
  
  If no arguments are provided, the interactive UI is ran.